### PR TITLE
Add technical indicators and risk management

### DIFF
--- a/config/config.py
+++ b/config/config.py
@@ -22,6 +22,10 @@ class Config:
     COOLDOWN_TIME: int = 3600  # segundos
     MIN_USDT_FOR_TRADE: float = 10.0
     PERCENT_USDT_TO_INVEST_PER_TRADE: float = 0.95
+    # Percentual do valor total do portfólio utilizado em cada operação
+    PERCENT_PORTFOLIO_PER_TRADE: float = 0.10
+    # Perda máxima permitida por dia em USDT antes de pausar as operações
+    MAX_DAILY_LOSS_USDT: float = 50.0
     MAX_COINS_TO_ANALYZE: int = 20
 
     # Configurações de LLM

--- a/utils/helpers.py
+++ b/utils/helpers.py
@@ -44,6 +44,12 @@ def log_trade(action, symbol, quantity, price, total_value, fees_paid=0.0, net_v
         print(f"[{timestamp}] [TRADE] {action} {quantity} {symbol} @ {price} = {total_value:.2f} USDT")
 
 
+def log_performance(label, value):
+    """Loga métricas de performance como lucro ou perda acumulada"""
+    timestamp = datetime.now().strftime('%Y-%m-%d %H:%M:%S')
+    print(f"[{timestamp}] [PERF] {label}: {value:.2f} USDT")
+
+
 def format_percentage(value, precision=2):
     """
     Formata um valor como percentagem


### PR DESCRIPTION
## Summary
- compute SMA, EMA and MACD indicators
- enhance coin selection with trend filters using SMA/MACD
- add risk management settings in config
- implement daily loss limit and performance logging
- invest a percentage of portfolio per trade

## Testing
- `python3 -m py_compile analysis/technical.py strategy/selection.py strategy/trading.py utils/helpers.py config/config.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684087f763208321bdbea59a6870f190